### PR TITLE
Fix CMakeLists to properly configure mutilsConfig.cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@
 *.exe
 *.out
 *.app
+
+# Build directories
+build/
+build-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,14 @@
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 3.15.4)
 project (mutils)
+include(GNUInstallDirs)
 
 #Versions
 set(mutils_VERSION 1.0)
 
 #CXX FLAGS
-set(CMAKE_CXX_FLAGS_RELEASE "-std=c++14 -fPIC")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_RELEASE}")
-set(CMAKE_CXX_FLAGS_DEBUG "-std=c++14 -fPIC -g")
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
 set(CMAKE_SHARED_LINKER_FLAGS "-shared --enable-new-dtags")
 
 if ( NOT DEFINED CMAKE_INSTALL_LIBDIR )
@@ -18,8 +19,9 @@ add_library(mutils SHARED utils.cpp abiutils.cpp)
 target_include_directories(mutils PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 #Make install
-install(TARGETS mutils EXPORT mutils
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS mutils EXPORT mutilsTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(DIRECTORY include/mutils
         DESTINATION include)
 
@@ -30,24 +32,21 @@ write_basic_package_version_file(
   COMPATIBILITY AnyNewerVersion
 )
 
-export (EXPORT mutils
-  FILE "${CMAKE_CURRENT_BINARY_DIR}/mutils/mutilsTargets.cmake"
-)
-
-configure_file (mutilsConfig.cmake
-  "${CMAKE_CURRENT_BINARY_DIR}/mutils/mutilsConfig.cmake"
-  COPYONLY
-)
-
 set(ConfigPackageLocation lib/cmake/mutils)
-install(EXPORT mutils
-  FILE mutilsTargets.cmake
-  DESTINATION ${ConfigPackageLocation}
+
+configure_package_config_file(mutilsConfig.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/mutils/mutilsConfig.cmake"
+    INSTALL_DESTINATION ${ConfigPackageLocation}
+    PATH_VARS CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR ConfigPackageLocation
 )
 
-install(
-  FILES
-    mutilsConfig.cmake
+install(EXPORT mutilsTargets
+    FILE mutilsTargets.cmake
+    NAMESPACE mutils::
+    DESTINATION ${ConfigPackageLocation})
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/mutils/mutilsConfig.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/mutils/mutilsConfigVersion.cmake"
   DESTINATION ${ConfigPackageLocation}
 )

--- a/mutilsConfig.cmake
+++ b/mutilsConfig.cmake
@@ -1,2 +1,7 @@
-set(mutils_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include")
-set(mutils_LIBRARIES "-L${CMAKE_INSTALL_PREFIX}/lib -lmutils")
+@PACKAGE_INIT@
+
+set_and_check(mutils_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+set(mutils_LIBRARIES "-L@PACKAGE_CMAKE_INSTALL_LIBDIR@ -lmutils")
+include("@PACKAGE_ConfigPackageLocation@/mutilsTargets.cmake")
+
+check_required_components(mutils)


### PR DESCRIPTION
Using `${CMAKE_INSTALL_PREFIX}` in mutilsConfig.cmake doesn't work because that variable is not expanded when "make install" is executed, so the mutilsConfig.cmake that gets installed to e.g. /usr/local/lib/cmake still has the literal string `${CMAKE_INSTALL_PREFIX}` in it. Then when another Cmake project uses find_package(mutils), it loads mutilsConfig.cmake and replaces `${CMAKE_INSTALL_PREFIX}` with whatever its current value is for that project, even if it's some other directory like ~/.local/ and not the directory where mutils is installed. This results in the confusing error message that mutils was found, but libmutils.so could not be found, because Cmake is looking in the wrong directory after expanding `${CMAKE_INSTALL_PREFIX}` in the definition of mutils_LIBRARIES.

The fix is to use the configure_package_config_file command from CMakePackageConfigHelpers, and the variable `PACKAGE_CMAKE_INSTALL_LIBDIR` which gets expanded during `make install`. I copied these commands from Derecho's CMakeLists.txt where they work correctly for installing the package so that it can be used by another CMake project.